### PR TITLE
Increase livenessProbe settings for Key Connector

### DIFF
--- a/charts/self-host/templates/key-connector.yaml
+++ b/charts/self-host/templates/key-connector.yaml
@@ -76,7 +76,7 @@ spec:
           httpGet:
             path: /alive
             port: 5000
-          initialDelaySeconds: 180
+          initialDelaySeconds: 300
         ports:
         - containerPort: 5000
         resources:

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -282,7 +282,7 @@ component:
     podServiceAccount:
   keyConnector:
     # Enable or disable the Key Connector component
-    enabled: true
+    enabled: false
     # Additional deployment annotations
     annotations: {}
     # Additional deployment labels

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -282,7 +282,7 @@ component:
     podServiceAccount:
   keyConnector:
     # Enable or disable the Key Connector component
-    enabled: false
+    enabled: true
     # Additional deployment annotations
     annotations: {}
     # Additional deployment labels


### PR DESCRIPTION
Fixes the liveness probe issues seen in deployments by increasing the amount of time for `initialDelaySeconds`.