### PR TITLE
 Ee cleanup fix

### DIFF
--- a/scripts/cleanup_branches.sh
+++ b/scripts/cleanup_branches.sh
@@ -45,6 +45,6 @@ CURRENT_BRANCHES=$(get_current_branches)
 # Find branches to delete
 for branch in $CURRENT_BRANCHES; do
   if ! echo "$ALL_EXTERNAL_BRANCHES" | grep -q "^$branch$"; then
-    delete_branch "$branch"
+    delete_branch "ee-$branch"
   fi
 done


### PR DESCRIPTION
## 🎟️ Tracking
n/a

## 📔 Objective
resolve branch cleanup failing jobs. The script is storing the ee-charts branch names after trimming the ee- prefix to make comparison against the server branch names more accurate and easier. simply adding the prefix back for the delete command at the bottom

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
